### PR TITLE
Update link to releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #  Centrifuge Protocol Yellow Paper
-To read the latest PDF version of the paper, check out the [releases on github](https://github.com/centrifuge/yellowpaper/releases)
+To read the latest PDF version of the paper, check out the [releases on github](https://github.com/centrifuge/protocol/releases)
 
 ## Building 
 The easiest way to generate a PDF out of the tex file is with docker:


### PR DESCRIPTION
This PR updates the link to the latest release of the centrifuge protocol. The previous [link](https://github.com/centrifuge/yellowpaper/releases) is a 404 - not found.